### PR TITLE
Inefficient way of using regexp

### DIFF
--- a/lib/webtail/stdin.rb
+++ b/lib/webtail/stdin.rb
@@ -6,6 +6,7 @@ module Webtail
       "&lt;" => "<",
       "&gt;" => ">",
     }
+    ENTITY_KEYS_REGEXP = Regexp.union(ENTITY_MAP.keys)
 
     def run
       STDIN.each do |line|
@@ -22,7 +23,7 @@ module Webtail
     end
 
     def unescape_entity(str)
-      str.gsub(Regexp.union(ENTITY_MAP.keys)) {|key| ENTITY_MAP[key] }
+      str.gsub(ENTITY_KEYS_REGEXP) {|key| ENTITY_MAP[key] }
     end
   end
 end


### PR DESCRIPTION
Thanks to [@hotchpotch's comment](https://github.com/r7kamura/webtail/commit/d6f63158e6acaa79fb381239db799f93af19f93d#commitcomment-1684988),
I found there is inefficient way of using regexp in Webtail::Stdin module.
