### PR TITLE
コマンドライン引数の--portに指定された値がうまく取得できてないのを修正しました

### DIFF
--- a/bin/webtail
+++ b/bin/webtail
@@ -4,7 +4,7 @@ require "slop"
 argv = ARGV.dup
 slop = Slop.new(:strict => true, :help => true)
 slop.banner "$ tail -f ... | webtail [options]"
-slop.on :p, :port, "port number for http server (default is 9999)"
+slop.on :p, :port=, "port number for http server (default is 9999)"
 begin
   slop.parse!(argv)
 rescue => e


### PR DESCRIPTION
どうもコマンド引数の解析に使ってるSlopの使い方が微妙に違っているっぽくて
誤: slop.on :p, :port, "port number for http server (default is 9999)"
正: slop.on :p, :port=, "port number for http server (default is 9999)"
とすべきみたいです。前者だと--portが指定されていたときは常にtrueが代入されてしまうみたいです。

以下この問題の再現手順になります
$ mkdir ./tmp
$ cd ./tmp
$ git clone git://github.com/r7kamura/webtail.git
$ cd ./webtail
$ bundle exec ruby -lib bin/webtail --port=7777
/home/kimoto/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/webrick/utils.rb:75:in `getaddrinfo': can't convert true into String (TypeError)
    from /home/kimoto/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/webrick/utils.rb:75:in`create_listeners'
    from /home/kimoto/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/webrick/server.rb:82:in `listen'
    from /home/kimoto/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/webrick/server.rb:70:in`initialize'
    from /home/kimoto/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/webrick/httpserver.rb:45:in `initialize'
    from /home/kimoto/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rack-1.4.1/lib/rack/handler/webrick.rb:10:in`new'
    from /home/kimoto/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/rack-1.4.1/lib/rack/handler/webrick.rb:10:in `run'
    from /home/kimoto/tmp/webtail/lib/webtail/app.rb:6:in`run'
    from /home/kimoto/tmp/webtail/lib/webtail.rb:22:in `block (2 levels) in run'
    from /home/kimoto/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/eventmachine-0.12.10/lib/eventmachine.rb:1060:in`call'
    from /home/kimoto/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/eventmachine-0.12.10/lib/eventmachine.rb:1060:in `block in spawn_threadpool'
