### PR TITLE
Fix slop version to 3.6

### DIFF
--- a/webtail.gemspec
+++ b/webtail.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "eventmachine"
   gem.add_dependency "em-websocket"
   gem.add_dependency "sinatra"
-  gem.add_dependency "slop"
+  gem.add_dependency "slop", "~> 3.6"
   gem.add_dependency "launchy", ">= 2.0.6"
 end


### PR DESCRIPTION
Currently Slop gem updated to 4.0, which has incompatiable changes, so option parsing in bin/slop does not work. So I fixed version in gemspec to use 3.6.
